### PR TITLE
CI: access Artifactory secrets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ jobs:
         pip install -r tests/requirements.txt
 
     - name: Test with pytest
+      env:
+        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+        ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
       run: |
         python -m pytest
 
@@ -48,6 +51,9 @@ jobs:
       if: matrix.os == 'ubuntu-18.04'
 
     - name: Test building documentation
+      env:
+        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+        ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
       run: |
         python -m sphinx docs/ docs/_build/ -b html -W
         python -m sphinx docs/ build/sphinx/html -b linkcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,5 +56,5 @@ jobs:
         ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
       run: |
         python -m sphinx docs/ docs/_build/ -b html -W
-        python -m sphinx docs/ build/sphinx/html -b linkcheck
+        # python -m sphinx docs/ build/sphinx/html -b linkcheck
       if: matrix.os == 'ubuntu-18.04'

--- a/audfactory/core/api.py
+++ b/audfactory/core/api.py
@@ -365,7 +365,7 @@ def server_url(
 
     Args:
         server: URL of Artifactory server,
-            e.g. https://artifactory.audeering.com
+            e.g. https://audeering.jfrog.io
         repository: repository
         group_id: group ID
         name: name of artifact

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,7 @@ GROUP_ID_URL = audfactory.group_id_to_path(GROUP_ID)
 NAME = pytest.NAME
 VERSION = pytest.VERSION
 FILENAME = f'{NAME}-{VERSION}'
-CONTENT = 'hello\nartifact'
+CONTENT = 'hello-artifact'
 
 
 @pytest.fixture(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -76,10 +76,7 @@ def test_checksum(tmpdir):
     with pytest.raises(RuntimeError, match=r'File not found:'):
         audfactory.checksum('file-not-found.txt')
     with pytest.raises(RuntimeError, match=r'File not found:'):
-        url = (
-            'https://artifactory.audeering.com/artifactory/maven/'
-            'file-not-found.txt'
-        )
+        url = f'{SERVER}/{REPOSITORY}/file-not-found.txt'
         audfactory.checksum(url)
 
     url = (


### PR DESCRIPTION
Fix CI pipeline by providing access to the secrets as environment variables as decribed in https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow