### PR TITLE
Fix audfactory.versions() for missing permissions

### DIFF
--- a/audfactory/core/api.py
+++ b/audfactory/core/api.py
@@ -429,11 +429,11 @@ def versions(
         name=name,
     )
     path = _path(artifact_url)
-    if not path.exists():
-        versions = []
-    else:
+    try:
         versions = [os.path.basename(str(p)) for p in path if p.is_dir]
         versions = [v for v in versions if audeer.is_semantic_version(v)]
+    except (FileNotFoundError, RuntimeError):
+        versions = []
     return audeer.sort_versions(versions)
 
 


### PR DESCRIPTION
At the moment we are doing:

```python
    if not path.exists():
        versions = []
    else:
        versions = [os.path.basename(str(p)) for p in path if p.is_dir]
        versions = [v for v in versions if audeer.is_semantic_version(v)]
```
The problem is that `path.exists()` raises a `RuntimeError` if you don't have the permissions to access that path.
So I swtichted to use a `try`-`except` statement instead.