### PR TITLE
DOC: more explicit on Artifactory authentication

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,28 +5,36 @@ Usage
 Authentication
 --------------
 
-Users have to create a config file :file:`~/.artifactory_python.cfg`,
-that assigns a username and `API key`_
-for every Artifactory server they want to use:
+To access an Artifactory server,
+store your username and `API key`_ in :file:`~/.artifactory_python.cfg`
 
 .. code-block:: cfg
 
-    [audeering.jfrog.io/artifactory]
+    [artifactory.audeering.com/artifactory]
     username = MY_USERNAME
     password = MY_API_KEY
 
-Alternatively, they can provide them as environment variables:
+and replace ``artifactory.audeering.com/artifactory``
+with your Artifactory server address.
+You can add several server entries.
+
+Alternatively, export the credentials as environment variables:
 
 .. code-block:: bash
 
-    $ export ARTIFACTORY_USERNAME="MY_USERNAME"
-    $ export ARTIFACTORY_API_KEY="MY_API_KEY"
+    export ARTIFACTORY_USERNAME="MY_USERNAME"
+    export ARTIFACTORY_API_KEY="MY_API_KEY"
 
-If you want to use multiple Artifactory users
-and environment variables
-instead of the config file
-you need to have the same username and API key
+The environment variables will be applied to all servers,
+which means you need to have the same username and API key
 on every server.
+You might lose access to artifacts on servers
+that are setup for anonymous access
+as it will always try to authenticate
+with the given username and password.
+In this case
+it is recommended to not use the environment variables.
+
 
 .. _API key: https://www.jfrog.com/confluence/display/JFROG/User+Profile#UserProfile-APIKey
 


### PR DESCRIPTION
This expands the authentication section in the docs with:

* state that you have to replace the server address in the config with your server
* switch to our internal server URL, as most of us will need this URL
* state that the environment variables might fail if you use several servers and on anonymous access

![image](https://user-images.githubusercontent.com/173624/122381147-e1656880-cf68-11eb-94fc-7a34e8af61d6.png)
