### PR TITLE
FIX: ignore empty string arguments in url()

### DIFF
--- a/audfactory/core/api.py
+++ b/audfactory/core/api.py
@@ -385,16 +385,16 @@ def url(
 
     """
     url = server
-    if repository is None:
+    if not repository:
         return url
-    else:
-        url += f'/{repository}'
+
+    url += f'/{repository}'
     if group_id:
         group_id = group_id_to_path(group_id)
         url += f'/{group_id}'
-    if name is not None:
+    if name:
         url += f'/{name}'
-    if version is not None:
+    if version:
         url += f'/{version}'
     return url
 

--- a/audfactory/core/api.py
+++ b/audfactory/core/api.py
@@ -389,7 +389,7 @@ def url(
         return url
     else:
         url += f'/{repository}'
-    if group_id is not None:
+    if group_id:
         group_id = group_id_to_path(group_id)
         url += f'/{group_id}'
     if name is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -338,6 +338,13 @@ def test_rest_api_get(url, expected_text):
                 f'com/audeering/data/database/1.1.0'
             ),
         ),
+        (  # ignore group_id == ''
+            '',
+            'database',
+            'maven',
+            '1.1.0',
+            f'{SERVER}/maven/database/1.1.0',
+        ),
     ],
 )
 def test_url(group_id, name, version, repository, expected_url):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -308,10 +308,24 @@ def test_rest_api_get(url, expected_text):
             SERVER,
         ),
         (
+            'group_id',
+            'name',
+            '',
+            '1.0.0',
+            SERVER,
+        ),
+        (
             None,
             None,
             'maven',
             None,
+            f'{SERVER}/maven',
+        ),
+        (
+            '',
+            '',
+            'maven',
+            '',
             f'{SERVER}/maven',
         ),
         (
@@ -337,13 +351,6 @@ def test_rest_api_get(url, expected_text):
                 f'{SERVER}/maven/'
                 f'com/audeering/data/database/1.1.0'
             ),
-        ),
-        (  # ignore group_id == ''
-            '',
-            'database',
-            'maven',
-            '1.1.0',
-            f'{SERVER}/maven/database/1.1.0',
         ),
     ],
 )


### PR DESCRIPTION
Closes #25 

### Example

```python
audfactory.url(
    'https://host',
    group_id='',
    name='name',
    repository='repo',
    version='1.0.0',
)
```
```
https://host/repo/name/1.0.0
```

```python
audfactory.url(
    'https://host',
    group_id='',
    name='',
    repository='repo',
    version='',
)
```
```
https://host/repo
```

```python
audfactory.url(
    'https://host',
    repository='',
)
```
```
https://host
```