### PR TITLE
DOC: extend authentication section

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -48,7 +48,7 @@ at the beginning:
     os.environ['ARTIFACTORY_USERNAME'] = 'MY_USERNAME2'
     os.environ['ARTIFACTORY_API_KEY'] = 'MY_API_KEY2'
 
-When request to authenticate for a configured server URL,
+When authentication is requested for a configured server URL,
 the corresponding username and password pair
 is returned.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,20 +5,69 @@ Usage
 Authentication
 --------------
 
+Artifactory servers can allow anonymous access
+by logging in with a fixed pair
+of ``'anonymous'`` as username
+and ``''`` as password.
+This is the default behavior of :mod:`audfactory`.
+
+.. jupyter-execute::
+
+    import audfactory
+
+    audfactory.authentification('https://artifactory.domain.com/artifactory')
+
 To access an Artifactory server,
-store your username and `API key`_ in :file:`~/.artifactory_python.cfg`
+that requires logging in with a username and password,
+store your username and `API key`_
+in :file:`~/.artifactory_python.cfg`
+using separate sections for every server.
+Every section is marked
+by the server URL in square brackets
+without the ``https://`` or ``http://``
+at the beginning.
 
 .. code-block:: cfg
 
-    [artifactory.audeering.com/artifactory]
-    username = MY_USERNAME
-    password = MY_API_KEY
+    [artifactory1.domain.com/artifactory]
+    username = MY_USERNAME1
+    password = MY_API_KEY1
 
-and replace ``artifactory.audeering.com/artifactory``
-with your Artifactory server address.
-You can add several server entries.
+    [artifactory2.domain.com/artifactory]
+    username = MY_USERNAME2
+    password = MY_API_KEY2
 
-Alternatively, export the credentials as environment variables:
+.. jupyter-execute::
+    :hide-code:
+    :hide-output:
+
+    import os
+
+    os.environ['ARTIFACTORY_USERNAME'] = 'MY_USERNAME2'
+    os.environ['ARTIFACTORY_API_KEY'] = 'MY_API_KEY2'
+
+.. jupyter-execute::
+
+    audfactory.authentification('https://artifactory2.domain.com/artifactory')
+
+Anonymous access is still used
+for every server
+not listed in the file.
+
+.. jupyter-execute::
+    :hide-code:
+    :hide-output:
+
+    del os.environ['ARTIFACTORY_USERNAME']
+    del os.environ['ARTIFACTORY_API_KEY']
+
+.. jupyter-execute::
+
+    audfactory.authentification('https://artifactory3.domain.com/artifactory')
+
+Alternatively,
+you can export
+the credentials as environment variables:
 
 .. code-block:: bash
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,7 +17,7 @@ This is the default behavior of :mod:`audfactory`.
 
     audfactory.authentification('https://artifactory.domain.com/artifactory')
 
-To access an Artifactory server,
+To access an Artifactory server
 that requires logging in with a username and password,
 store your username and `API key`_
 in :file:`~/.artifactory_python.cfg`
@@ -25,7 +25,7 @@ using separate sections for every server.
 Every section is marked
 by the server URL in square brackets
 without the ``https://`` or ``http://``
-at the beginning.
+at the beginning:
 
 .. code-block:: cfg
 
@@ -45,6 +45,10 @@ at the beginning.
 
     os.environ['ARTIFACTORY_USERNAME'] = 'MY_USERNAME2'
     os.environ['ARTIFACTORY_API_KEY'] = 'MY_API_KEY2'
+
+When request to authenticate for a configured URL,
+the corresponding username and password pair
+is returned.
 
 .. jupyter-execute::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,6 +37,8 @@ at the beginning:
     username = MY_USERNAME2
     password = MY_API_KEY2
 
+.. Workaround to allow correct audfactory.authentification() output
+.. without having an actual config file
 .. jupyter-execute::
     :hide-code:
     :hide-output:
@@ -58,6 +60,8 @@ Anonymous access is still used
 for every server
 not listed in the file.
 
+.. We need to delete the workaround environment variables
+.. to allow anonymous access again
 .. jupyter-execute::
     :hide-code:
     :hide-output:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -46,7 +46,7 @@ at the beginning:
     os.environ['ARTIFACTORY_USERNAME'] = 'MY_USERNAME2'
     os.environ['ARTIFACTORY_API_KEY'] = 'MY_API_KEY2'
 
-When request to authenticate for a configured URL,
+When request to authenticate for a configured server URL,
 the corresponding username and password pair
 is returned.
 


### PR DESCRIPTION
This extends the Authentication section under Usage.

It adds a discussion of anonymous access as the default behavior,
shows how to configure more than one server,
and adds example outputs of `audfactory.authentification(url)`.

![image](https://user-images.githubusercontent.com/173624/144006979-8170c71f-2479-4a74-8c7e-bb8e887180b1.png)
