### PR TITLE
Replace Python 3.6 by Python 3.9 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.8'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, windows-latest, macOS-latest ]
-        python-version: [3.6]
+        os: [ ubuntu-20.04, windows-latest, macOS-latest ]
+        python-version: [3.8]
         include:
           - os: ubuntu-latest
             python-version: 3.7
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
 
     steps:
     - uses: actions/checkout@v2
@@ -48,10 +48,10 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
 
     - name: Test building documentation
       run: |
         python -m sphinx docs/ docs/_build/ -b html -W
-        # python -m sphinx docs/ build/sphinx/html -b linkcheck
-      if: matrix.os == 'ubuntu-18.04'
+        python -m sphinx docs/ build/sphinx/html -b linkcheck
+      if: matrix.os == 'ubuntu-20.04'

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Have a look at the installation_ and usage_ instructions.
 
 .. _Artifactory: https://jfrog.com/artifactory/
 .. _dohq-artifactory: https://github.com/devopshq/artifactory
-.. _installation: https://audeering.github.io/audfactory/install.html
+.. _installation: https://audeering.github.io/audfactory/installation.html
 .. _usage: https://audeering.github.io/audfactory/usage.html
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,9 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering
 
 


### PR DESCRIPTION
* Use Python 3.8 for building documentation and publish package
* Use Ubuntu 20.04
* Re-enable link check