### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,14 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, windows-latest, macOS-latest ]
-        python-version: [3.8]
+        python-version: [ '3.8' ]
         include:
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: '3.7'
           - os: ubuntu-latest
-            python-version: 3.9
+            python-version: '3.9'
+          - os: ubuntu-latest
+            python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
 
 


### PR DESCRIPTION
Add test for Python 3.10 under Ubuntu and mention Python 3.10 as supported version in `setup.cfg`.