### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,12 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [
     'audeer >=1.11.0',
-    'dohq-artifactory >=0.9.0',
+    'dohq-artifactory >=0.9.1',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)


### PR DESCRIPTION
Add test for Python 3.11 under Ubuntu and mention Python 3.11 as supported version in `setup.cfg`.

It requires `dohq-artifactory >=0.8.2` which introduced support for Python 3.11, compare https://github.com/devopshq/artifactory/pull/376