### PR TITLE
Fix support for Python 3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 packages = find:
 install_requires =
     audeer >=1.11.0
-    dohq-artifactory >=0.8.2
+    dohq-artifactory >=0.8.1
 setup_requires =
     setuptools_scm
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audeer>=1.11.0
-    dohq-artifactory>=0.7.377
+    audeer >=1.11.0
+    dohq-artifactory >=0.8.2
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
To avoid errors such as reported in https://github.com/audeering/audb/issues/254 we have to make sure `audfactory` works with Python 3.10. Full support for Python 3.10 was only added in `dohq-artifactory` 0.8.1, so we shopuld require at least this version.