### PR TITLE
Fix version() for server with no access rights

### DIFF
--- a/audfactory/core/api.py
+++ b/audfactory/core/api.py
@@ -435,9 +435,9 @@ def versions(
     except (
             FileNotFoundError,
             RuntimeError,
-            # no access dohq-artifactory<0.8
+            # no access rights to server with dohq-artifactory<0.8
             requests.exceptions.HTTPError,
-            # no access dohq-artifactory>=0.8
+            # no access rights to server with dohq-artifactory>=0.8
             dohq_artifactory.exception.ArtifactoryException,
     ):
         versions = []

--- a/audfactory/core/api.py
+++ b/audfactory/core/api.py
@@ -9,6 +9,7 @@ from artifactory import (
     sha1sum,
     sha256sum,
 )
+import dohq_artifactory
 import requests
 
 import audeer
@@ -431,7 +432,14 @@ def versions(
     try:
         versions = [os.path.basename(str(p)) for p in path if p.is_dir]
         versions = [v for v in versions if audeer.is_semantic_version(v)]
-    except (FileNotFoundError, RuntimeError, requests.exceptions.HTTPError):
+    except (
+            FileNotFoundError,
+            RuntimeError,
+            # no access dohq-artifactory<0.8
+            requests.exceptions.HTTPError,
+            # no access dohq-artifactory>=0.8
+            dohq_artifactory.exception.ArtifactoryException,
+    ):
         versions = []
     return audeer.sort_versions(versions)
 


### PR DESCRIPTION
This fixes `audfactory.versions()` to behave the same for `dohq-artifactory>=0.8` as they changed the error they throw when you don't have access to an artifactory server.

In https://github.com/audeering/audfactory/pull/45 we introduced a dependency on `dohq-artifactory>=0.8.1` so we need to adjust accordingly. As you are still able to install an older version of `dohq-artifactory` I would propose to also leave the old part of the code to be on the safe side. 

I did not add a test for this as this would require the use of a public server to which we don't have access.