### PR TITLE
TST: add a test for versions() with no-access rights

### DIFF
--- a/audfactory/core/api.py
+++ b/audfactory/core/api.py
@@ -435,6 +435,9 @@ def versions(
     except (
             FileNotFoundError,
             RuntimeError,
+    ):
+        versions = []
+    except (
             # no access rights to server with dohq-artifactory<0.8
             requests.exceptions.HTTPError,
             # no access rights to server with dohq-artifactory>=0.8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,3 +39,20 @@ def cleanup_session():
 def cleanup_test():
     yield
     cleanup()
+
+
+@pytest.fixture(scope='function', autouse=False)
+def no_artifactory_access_rights():
+    current_username = os.environ.get('ARTIFACTORY_USERNAME', False)
+    current_api_key = os.environ.get('ARTIFACTORY_API_KEY', False)
+    os.environ['ARTIFACTORY_USERNAME'] = 'non-existing-user'
+    os.environ['ARTIFACTORY_API_KEY'] = 'non-existing-password'
+    yield
+    if current_username:
+        os.environ["ARTIFACTORY_USERNAME"] = current_username
+    else:
+        del os.environ['ARTIFACTORY_USERNAME']
+    if current_api_key:
+        os.environ['ARTIFACTORY_API_KEY'] = current_api_key
+    else:
+        del os.environ['ARTIFACTORY_API_KEY']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -388,3 +388,7 @@ def test_versions(group_id, name, expected_versions):
         name,
     )
     assert versions == expected_versions
+
+
+def test_versions_no_access(no_artifactory_access_rights):
+    assert audfactory.versions(SERVER, REPOSITORY, 'group_id') == []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -391,4 +391,4 @@ def test_versions(group_id, name, expected_versions):
 
 
 def test_versions_no_access(no_artifactory_access_rights):
-    assert audfactory.versions(SERVER, REPOSITORY, 'group_id') == []
+    assert audfactory.versions(SERVER, REPOSITORY, 'group_id', 'name') == []


### PR DESCRIPTION
Relates to https://github.com/audeering/audfactory/issues/49 and #50

This adds a test that fails if the changes added in https://github.com/audeering/audfactory/pull/50 would not have been added.
In addition, it splits up the `except` statement in `audfactory.versions()` so we don't get full code coverage if the test introduced here would be missing.