### PR TITLE
Require dohq-artifactory>=0.9.0

### DIFF
--- a/audfactory/core/api.py
+++ b/audfactory/core/api.py
@@ -299,6 +299,7 @@ def path(
         >>> for content in artifactory_path:
         ...     print(os.path.basename(str(content)))
         ...
+        attachment
         db
         media
         meta

--- a/audfactory/core/api.py
+++ b/audfactory/core/api.py
@@ -164,6 +164,7 @@ def deploy(
             sha1=sha1,
             sha256=sha256,
             parameters=parameters,
+            quote_parameters=True,
         )
 
     if verbose:  # pragma: no cover

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -93,7 +93,7 @@ In this case
 it is recommended to not use the environment variables.
 
 
-.. _API key: https://www.jfrog.com/confluence/display/JFROG/User+Profile#UserProfile-APIKey
+.. _API key: https://jfrog.com/help/r/jfrog-platform-administration-documentation/api-key
 
 
 Artifactory

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 packages = find:
 install_requires =
     audeer >=1.11.0
-    dohq-artifactory >=0.8.1
+    dohq-artifactory >=0.9.0
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
This fixes a warning shown for the new `quote_parameter` added in version 0.9.0 of `artifactory`, see https://github.com/devopshq/artifactory/issues/408.

In order to make the tests pass it also
* fixes a broken link to the JFROG documentation
* fixes the output of the doctest as `emodb` now contains attachments