### PR TITLE
Fix: remove Python 3.11 from supported versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [


### PR DESCRIPTION
In https://github.com/audeering/audfactory/pull/56 we wrongly added Python 3.11 to the supported Python versions.